### PR TITLE
fix: Login recursive refresh repair and homepage redirect repair

### DIFF
--- a/src/components/bar/Navbar.vue
+++ b/src/components/bar/Navbar.vue
@@ -43,7 +43,7 @@
           // 返回主页
           onClickBack2Home() {
             window.localStorage.removeItem('Power_appId')
-            this.$router.push("/");
+            this.$router.push("/admin/app");
           },
 
           // 退出登录

--- a/src/components/login/LoginHomepage.vue
+++ b/src/components/login/LoginHomepage.vue
@@ -57,7 +57,7 @@ export default {
         if (ret === null || ret === undefined) {
           console.log('ifLogin failed, need reLogin')
         } else {
-          this.$router.push("/admin/app")
+          this.$router.push("/");
         }
       }, error => {
         window.localStorage.removeItem('PowerJwt');


### PR DESCRIPTION
In the absence of login, there may be an issue of recursively refreshing the login page. To fix the above case, it is necessary to also modify and return to the homepage.