### PR TITLE
feat: build docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # PowerJob-Console
+
 分布式调度与计算框架——PowerJob 前端页面
 
-项目文档：https://www.yuque.com/powerjob/guidence
+项目文档：<https://www.yuque.com/powerjob/guidence>
 
 # 命令
+
 npm run serve（使用 .env.dev ，请求 localhost:7700）
 
 npm run build（使用 .env.product）
 
 npm run build_spring（使用 .env.spring，请求 /，构建内置于 SpringBoot 的 vue project）
+
+# 使用容器启动
+
+修改`docker-compose.yml`文件，将`API_HOST`和`API_PORT`两个环境变量设置为后端接口地址。
+
+```bash
+docker compose up -d --build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  console:
+    restart: always
+    container_name: powerjob-console
+    image: powerjob/powerjob-console:latest
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    environment:
+      API_HOST: 127.0.0.1
+      PORT: 7700
+    ports:
+    - "8880:80"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+### Builder
+FROM node:14.20.0 AS builder
+
+WORKDIR /app
+# RUN npm config set registry https://registry.npmmirror.com
+
+COPY package.json package.json
+RUN npm install
+
+COPY public public
+COPY src src
+COPY .env.product .env.product
+RUN npm run build
+
+### Runner
+FROM openresty/openresty:alpine-apk AS runner
+MAINTAINER "z.t.x@foxmail.com"
+
+COPY --from=builder /app/dist /app/dist
+
+ENV TZ=Asia/Shanghai
+ENV API_HOST='127.0.0.1'
+ENV API_PORT='7700'
+
+COPY docker/default.conf /etc/nginx/conf.d/
+COPY docker/env.main     /etc/nginx/conf.d/
+COPY docker/api.lua      /etc/nginx/lua/
+
+EXPOSE 80

--- a/docker/api.lua
+++ b/docker/api.lua
@@ -1,0 +1,19 @@
+local balancer = require "ngx.balancer"
+
+local api_host = os.getenv("API_HOST")
+local api_port = tonumber(os.getenv("API_PORT"))
+
+if not api_host then
+    ngx.log(ngx.ERR, "API_HOST is not set")
+    ngx.exit(500)
+end
+if not api_port then
+    ngx.log(ngx.ERR, "API_PORT is not a valid number: ", api_port)
+    ngx.exit(500)
+end
+
+local ok, err = balancer.set_current_peer(api_host, api_port)
+if not ok then
+    ngx.log(ngx.ERR, "Failed to set peer: ", err)
+    ngx.exit(502)
+end

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -1,0 +1,19 @@
+upstream api {
+    server 127.0.0.1;
+    balancer_by_lua_file /etc/nginx/lua/api.lua;
+}
+
+server {
+    listen 80;
+    root /app/dist;
+    try_files $uri $uri/ /index.html;
+
+    location /api/ {
+        proxy_pass http://api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Cache-Control no-cache;
+    }
+}

--- a/docker/env.main
+++ b/docker/env.main
@@ -1,0 +1,2 @@
+env API_HOST;
+env API_PORT;

--- a/src/main.js
+++ b/src/main.js
@@ -15,9 +15,8 @@ import store from "./store";
 import common from "./common";
 
 Vue.use(ElementUI);
-// let baseURL = "http://139.224.83.134:7700";
-let baseURL = process.env.VUE_APP_BASE_URL;
-// let baseURL = '/api';
+// let baseURL = process.env.VUE_APP_BASE_URL;
+let baseURL = '/api';
 
 let timeout = 10000;
 


### PR DESCRIPTION
新建了一个Docker镜像构建脚本，用于构建可在运行时动态修改后端接口地址的前端镜像。

> 参考资料：<https://www.yuque.com/powerjob/guidence/deploy_server#s5KN9>

**实现方式：** 使用openresty，在nginx中通过lua脚本动态配置后端地址。
**特点：** 镜像构建发布后，使用者可直接拉取镜像，只需要在部署时配置`API_HOST`与`API_PORT`两个环境变量即可。同时提供了`docker-compose`脚本，支持快速修改环境变量并部署，亦可基于此自定义构建镜像。